### PR TITLE
[FEAT] 온보딩 화면 구현

### DIFF
--- a/CaptureCat/CaptureCat/DesignSystem/Component/Button/Extension/Button+.swift
+++ b/CaptureCat/CaptureCat/DesignSystem/Component/Button/Extension/Button+.swift
@@ -14,7 +14,8 @@ extension Button {
         selectedForeground: Color = .white,
         unselectedBackground: Color = .white,
         unselectedForeground: Color = .gray09,
-        borderColor: Color? = .gray09,
+        selectedBorderColor: Color? = nil,
+        unselectedBorderColor: Color? = .gray04,
         icon: Image? = nil
     ) -> some View {
         buttonStyle(
@@ -24,7 +25,8 @@ extension Button {
                 selectedForeground: selectedForeground,
                 unselectedBackground: unselectedBackground,
                 unselectedForeground: unselectedForeground,
-                borderColor: borderColor,
+                selectedBorderColor: selectedBorderColor,
+                unselectedBorderColor: unselectedBorderColor,
                 icon: icon
             )
         )

--- a/CaptureCat/CaptureCat/DesignSystem/Component/Button/Extension/Button+.swift
+++ b/CaptureCat/CaptureCat/DesignSystem/Component/Button/Extension/Button+.swift
@@ -33,7 +33,7 @@ extension Button {
     }
     
     func primaryStyle(
-        cornerRadius: CGFloat = 8,
+        cornerRadius: CGFloat = 4,
         backgroundColor: Color = .primary01,
         foregroundColor: Color = .white,
         verticalPadding: CGFloat = 14

--- a/CaptureCat/CaptureCat/DesignSystem/Component/Button/Style/ChipButtonStyle.swift
+++ b/CaptureCat/CaptureCat/DesignSystem/Component/Button/Style/ChipButtonStyle.swift
@@ -45,7 +45,7 @@ struct ChipButtonStyle: ButtonStyle {
             RoundedRectangle(cornerRadius: 20)
                 .stroke(
                     (isSelected ? selectedBorderColor : unselectedBorderColor) ?? (isSelected ? selectedBackground : unselectedBackground),
-                    lineWidth: 2
+                    lineWidth: 1.5
                 )
         )
         .cornerRadius(20)

--- a/CaptureCat/CaptureCat/DesignSystem/Component/Button/Style/ChipButtonStyle.swift
+++ b/CaptureCat/CaptureCat/DesignSystem/Component/Button/Style/ChipButtonStyle.swift
@@ -13,7 +13,8 @@ struct ChipButtonStyle: ButtonStyle {
     let selectedForeground: Color
     let unselectedBackground: Color
     let unselectedForeground: Color
-    let borderColor: Color?
+    let selectedBorderColor: Color?
+    let unselectedBorderColor: Color?
     let icon: Image?
     
     func makeBody(configuration: Configuration) -> some View {
@@ -26,10 +27,10 @@ struct ChipButtonStyle: ButtonStyle {
                     .frame(width: 16, height: 16)
             }
             configuration.label
-                .CFont(.subhead02Bold)
+                .CFont(isSelected ? .subhead02Bold : .body02Regular)
         }
         .padding(.horizontal, 16)
-        .padding(.vertical, 12)
+        .padding(.vertical, 10)
         .foregroundColor(isSelected ? selectedForeground : unselectedForeground)
         .background(
             Group {
@@ -42,7 +43,10 @@ struct ChipButtonStyle: ButtonStyle {
         )
         .overlay(
             RoundedRectangle(cornerRadius: 20)
-                .stroke(borderColor ?? (isSelected ? selectedBackground : unselectedBackground), lineWidth: 2)
+                .stroke(
+                    (isSelected ? selectedBorderColor : unselectedBorderColor) ?? (isSelected ? selectedBackground : unselectedBackground),
+                    lineWidth: 2
+                )
         )
         .cornerRadius(20)
         .opacity(configuration.isPressed ? 0.7 : 1.0)

--- a/CaptureCat/CaptureCat/DesignSystem/Component/Button/Style/PrimaryButtonStyle.swift
+++ b/CaptureCat/CaptureCat/DesignSystem/Component/Button/Style/PrimaryButtonStyle.swift
@@ -8,18 +8,23 @@
 import SwiftUI
 
 struct PrimaryButtonStyle: ButtonStyle {
+    @Environment(\.isEnabled) private var isEnabled
+    
     let cornerRadius: CGFloat
     let backgroundColor: Color
     let foregroundColor: Color
     let verticalPadding: CGFloat
     
     func makeBody(configuration: Configuration) -> some View {
-        configuration.label
+        let background = isEnabled ? backgroundColor : Color.gray04
+        let foreground = isEnabled ? foregroundColor : Color.gray08
+        
+        return configuration.label
             .CFont(.subhead01Bold)
-            .foregroundColor(foregroundColor)
+            .foregroundColor(foreground)
             .frame(maxWidth: .infinity)
             .padding(.vertical, verticalPadding)
-            .background(backgroundColor)
+            .background(background)
             .cornerRadius(cornerRadius)
             .opacity(configuration.isPressed ? 0.7 : 1.0)
             .animation(.easeOut(duration: 0.2), value: configuration.isPressed)

--- a/CaptureCat/CaptureCat/DesignSystem/Component/Toast/ToastModifier.swift
+++ b/CaptureCat/CaptureCat/DesignSystem/Component/Toast/ToastModifier.swift
@@ -1,0 +1,44 @@
+//
+//  ToastModifier.swift
+//  CaptureCat
+//
+//  Created by minsong kim on 6/28/25.
+//
+
+import SwiftUI
+
+struct ToastModifier: ViewModifier {
+    @Binding var isShowing: Bool
+    let message: String
+    let textColor: Color
+    let duration: TimeInterval
+    
+    func body(content: Content) -> some View {
+        content
+            .overlay(alignment: .bottom) {
+                if isShowing {
+                    Text(message)
+                        .CFont(.subhead02Bold)
+                        .foregroundColor(textColor)
+                        .multilineTextAlignment(.center)
+                        .frame(height: 46)
+                        .frame(maxWidth: .infinity)
+                        .background(Color.black.opacity(0.75))
+                        .cornerRadius(8)
+                        .padding(.horizontal, 16)
+                        .padding(.bottom, 72)
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                }
+            }
+            .onChange(of: isShowing) { _, newValue in
+                if newValue {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + duration) {
+                        withAnimation {
+                            isShowing = false
+                        }
+                    }
+                }
+                
+            }
+    }
+}

--- a/CaptureCat/CaptureCat/DesignSystem/Component/Toast/View+toast.swift
+++ b/CaptureCat/CaptureCat/DesignSystem/Component/Toast/View+toast.swift
@@ -1,0 +1,24 @@
+//
+//  View+toast.swift
+//  CaptureCat
+//
+//  Created by minsong kim on 6/28/25.
+//
+
+import SwiftUI
+
+extension View {
+    func toast(isShowing: Binding<Bool>,
+               message: String,
+               textColor: Color = .white,
+               duration: TimeInterval = 1) -> some View {
+        self.modifier(
+            ToastModifier(
+                isShowing: isShowing,
+                message: message,
+                textColor: textColor,
+                duration: duration
+            )
+        )
+    }
+}

--- a/CaptureCat/CaptureCat/DesignSystem/Component/View/ScreenshotThumbnailView.swift
+++ b/CaptureCat/CaptureCat/DesignSystem/Component/View/ScreenshotThumbnailView.swift
@@ -1,0 +1,55 @@
+//
+//  ScreenshotThumbnailView.swift
+//  CaptureCat
+//
+//  Created by minsong kim on 6/28/25.
+//
+
+import SwiftUI
+import Photos
+
+struct ScreenshotThumbnailView: View {
+    @State private var image: UIImage? = nil
+    
+    let asset: PHAsset
+    let isSelected: Bool
+    
+    var body: some View {
+        ZStack(alignment: .topLeading) {
+            Group {
+                if let image {
+                    Image(uiImage: image)
+                        .resizable()
+                        .aspectRatio(45 / 76, contentMode: .fill)
+                } else {
+                    Color(white: 0.9)
+                        .onAppear { loadImage() }
+                }
+            }
+            .clipped()
+            
+            Image(systemName: "checkmark.square.fill")
+                .padding(6)
+                .foregroundColor(.primary01)
+                .opacity(isSelected ? 1 : 0.6)
+            
+        }
+        .overlay(
+            RoundedRectangle(cornerSize: .zero)
+                .stroke(isSelected ? Color.primary01 : Color.clear, lineWidth: 2)
+        )
+    }
+    
+    private func loadImage() {
+        let manager = PHCachingImageManager()
+        
+        manager.requestImage(
+            for: asset,
+            targetSize: .zero,
+            contentMode: .aspectFill,
+            options: nil
+        ) { image, _ in
+            self.image = image
+        }
+    }
+}

--- a/CaptureCat/CaptureCat/DesignSystem/Font/CFont.swift
+++ b/CaptureCat/CaptureCat/DesignSystem/Font/CFont.swift
@@ -155,10 +155,9 @@ struct CFontModifier: ViewModifier {
             forTextStyle: font.textStyle.toUIFontTextStyle()
         ).pointSize
         let appliedSize = font.fontSize
-        let extraSpacing = max(font.lineHeight - appliedSize, 0)
         
         return content
             .font(.custom(font.fontType.name, size: appliedSize, relativeTo: font.textStyle))
-            .lineSpacing(extraSpacing)
+            .lineSpacing(0)
     }
 }

--- a/CaptureCat/CaptureCat/Info.plist
+++ b/CaptureCat/CaptureCat/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>스크린샷을 불러오기 위해 사진 접근 권한이 필요합니다.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Pretendard-SemiBold.otf</string>

--- a/CaptureCat/CaptureCat/Info.plist
+++ b/CaptureCat/CaptureCat/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>스크린샷을 불러오기 위해 사진 접근 권한이 필요합니다.</string>
 	<key>UIAppFonts</key>

--- a/CaptureCat/CaptureCat/Presentation/Start/SelectMainTagView.swift
+++ b/CaptureCat/CaptureCat/Presentation/Start/SelectMainTagView.swift
@@ -1,0 +1,70 @@
+//
+//  SelectMainTagView.swift
+//  CaptureCat
+//
+//  Created by minsong kim on 6/28/25.
+//
+
+import SwiftUI
+
+struct SelectMainTagView: View {
+    @StateObject private var viewModel = SelectMainTagViewModel()
+    @State private var navigationToScreenshots = false
+    
+    var body: some View {
+        NavigationStack {
+            VStack(alignment: .leading) {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("자주 캡쳐하는 이미지가 있으신가요?")
+                        .CFont(.headline02Bold)
+                        .foregroundStyle(.text01)
+                    Text("관심 주제를 선택(5개 이하)해주시면\n캐치가 미리 태그로 만들어드려요.")
+                        .CFont(.body02Regular)
+                        .foregroundStyle(.text03)
+                }
+                .padding(.leading, 16)
+                .padding(.top, 16)
+                
+                VStack(alignment: .leading, spacing: 12) {
+                    ForEach(viewModel.rows, id: \.self) { row in
+                        HStack(spacing: 12) {
+                            ForEach(row) { topic in
+                                Button {
+                                    viewModel.toggle(topic)
+                                } label: {
+                                    Text(topic.title)
+                                }
+                                .chipStyle(
+                                    isSelected: viewModel.selected.contains(topic),
+                                    selectedBackground: .primary01,
+                                    selectedForeground: .white
+                                )
+                                
+                            }
+                            Spacer()
+                        }
+                    }
+                }
+                .padding(.horizontal, 16)
+                .padding(.top, 16)
+                
+                Spacer()
+                Button(viewModel.selectionText) {
+                    navigationToScreenshots = true
+                    print("선택 완료 \(viewModel.selected.map(\.title))")
+                }
+                .primaryStyle()
+                .disabled(viewModel.selected.isEmpty)
+                .padding(.horizontal, 16)
+            }
+            .navigationDestination(isPresented: $navigationToScreenshots) {
+                StartGetScreenshotView()
+                    .toolbar(.hidden, for: .navigationBar)
+            }
+        }
+    }
+}
+
+#Preview {
+    SelectMainTagView()
+}

--- a/CaptureCat/CaptureCat/Presentation/Start/SelectMainTagViewModel.swift
+++ b/CaptureCat/CaptureCat/Presentation/Start/SelectMainTagViewModel.swift
@@ -1,0 +1,49 @@
+//
+//  SelectMainTagViewModel.swift
+//  CaptureCat
+//
+//  Created by minsong kim on 6/28/25.
+//
+
+import Combine
+import SwiftUI
+
+// 화면에 표시할 토픽 모델
+struct Topic: Identifiable, Hashable {
+    let id = UUID()
+    let title: String
+}
+
+final class SelectMainTagViewModel: ObservableObject {
+    // 전체 토픽 목록
+    let topics: [Topic] = [
+        "쇼핑", "직무 관련", "레퍼런스", "코디",
+        "공부", "글귀", "여행", "자기계발",
+        "맛집", "new", "new", "new"
+    ].map(Topic.init)
+    
+    // 선택된 토픽 집합
+    @Published private(set) var selected: Set<Topic> = []
+    
+    // 최대 선택 개수
+    let maxSelection = 5
+    
+    // 토글 액션
+    func toggle(_ topic: Topic) {
+        if selected.contains(topic) {
+            selected.remove(topic)
+        } else if selected.count < maxSelection {
+            selected.insert(topic)
+        }
+    }
+    
+    // 현재 선택 개수 / 최대치 표시 문자열
+    var selectionText: String {
+        "선택 완료 \(selected.count)/\(maxSelection)"
+    }
+    
+    // 토픽을 4개씩 묶어주는 유틸
+    var rows: [[Topic]] {
+        topics.chunked(into: 4)
+    }
+}

--- a/CaptureCat/CaptureCat/Presentation/Start/StartGetScreenshotView.swift
+++ b/CaptureCat/CaptureCat/Presentation/Start/StartGetScreenshotView.swift
@@ -1,0 +1,66 @@
+//
+//  StartGetScreenshotView.swift
+//  CaptureCat
+//
+//  Created by minsong kim on 6/28/25.
+//
+
+import SwiftUI
+import Photos
+
+struct StartGetScreenshotView: View {
+    @StateObject private var manager = ScreenshotManager()
+    @State private var showOverlimitToast = false
+    
+    private let columns = Array(repeating: GridItem(.flexible(), spacing: 4), count: 3)
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("시작하기 전에 \n\(manager.totalCount)장의 스크린샷이 있어요.")
+                        .CFont(.headline02Bold)
+                        .foregroundStyle(.text01)
+                    Text("나중에도 저장할 수 있으니 먼저 필요한 이미지만 골라보세요.")
+                        .CFont(.body02Regular)
+                        .foregroundStyle(.text03)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.leading, 16)
+                .padding(.top, 16)
+                .padding(.bottom, 12)
+                
+                LazyVGrid(
+                    columns: columns,
+                    spacing: 4
+                ) {
+                    ForEach(manager.assets, id: \.localIdentifier) { asset in
+                        ScreenshotThumbnailView(
+                            asset: asset,
+                            isSelected: manager.selectedIDs.contains(asset.localIdentifier)
+                        )
+                        .onTapGesture {
+                            manager.toggleSelection(of: asset)
+                            
+                            if manager.selectedIDs.count > 20 {
+                                manager.toggleSelection(of: asset)
+                                withAnimation {
+                                    showOverlimitToast = true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            Spacer()
+            Button("정리하기 \(manager.selectedIDs.count)/20") {
+                print("선택")
+            }
+            .primaryStyle()
+            .disabled(manager.selectedIDs.isEmpty)
+            .padding(.horizontal, 16)
+            .padding(.bottom, 16)
+        }
+        .toast(isShowing: $showOverlimitToast, message: "최대 20장까지 선택할 수 있어요.", textColor: .error)
+    }
+}

--- a/CaptureCat/CaptureCat/Service/ScreenshotManager.swift
+++ b/CaptureCat/CaptureCat/Service/ScreenshotManager.swift
@@ -1,0 +1,109 @@
+//
+//  ScreenshotManager.swift
+//  CaptureCat
+//
+//  Created by minsong kim on 6/28/25.
+//
+
+import SwiftUI
+import Photos
+import Combine
+
+struct ScreenshotGroup: Identifiable {
+    let id: Date
+    var assets: [PHAsset]
+}
+
+// Photos 라이브러리에서 “스크린샷”만 가져와 관리하고, 선택·삭제 등의 로직을 처리하는 매니저
+final class ScreenshotManager: ObservableObject {
+    @Published private(set) var assets: [PHAsset] = []
+    @Published var selectedIDs: Set<String> = []
+    @Published private(set) var isLoading: Bool = false
+    
+    private var cancellables = Set<AnyCancellable>()
+    
+    // 전체 스크린샷 개수
+    var totalCount: Int {
+        assets.count
+    }
+    
+    init() {
+        requestPermissionAndFetch()
+    }
+    
+    // 사진 라이브러리 접근 권한 요청 후 페칭
+    private func requestPermissionAndFetch() {
+        PHPhotoLibrary.requestAuthorization { [weak self] status in
+            guard let self = self, status == .authorized else { return }
+            DispatchQueue.main.async {
+                self.fetchScreenshots()
+            }
+        }
+    }
+    
+    // 스크린샷만 필터링해서 assets에 할당
+    private func fetchScreenshots() {
+        isLoading = true
+        
+        let options = PHFetchOptions()
+        // 스크린샷 미디어 서브타입 필터
+        options.predicate = NSPredicate(
+            format: "mediaSubtype & %d != 0",
+            PHAssetMediaSubtype.photoScreenshot.rawValue
+        )
+        options.sortDescriptors = [
+            NSSortDescriptor(key: "creationDate", ascending: false)
+        ]
+        
+        let all = PHAsset.fetchAssets(with: .image, options: options)
+        var arr: [PHAsset] = []
+        all.enumerateObjects { asset, _, _ in
+            arr.append(asset)
+        }
+        
+        DispatchQueue.main.async {
+            self.assets = arr
+            self.isLoading = false
+        }
+    }
+    
+    // 선택된 에셋 토글
+    func toggleSelection(of asset: PHAsset) {
+        let id = asset.localIdentifier
+        if selectedIDs.contains(id) {
+            selectedIDs.remove(id)
+        } else {
+            selectedIDs.insert(id)
+        }
+    }
+    
+    // 모든 스크린샷 선택
+    func selectAll() {
+        assets.map(\.localIdentifier)
+            .forEach { selectedIDs.insert($0) }
+    }
+    
+    // 선택 해제
+    func deselectAll() {
+        selectedIDs.removeAll()
+    }
+    
+    // 선택된 스크린샷 삭제
+    func delete(assets toDelete: [PHAsset], completion: ((Bool, Error?) -> Void)? = nil) {
+        PHPhotoLibrary.shared().performChanges({
+            PHAssetChangeRequest.deleteAssets(toDelete as NSFastEnumeration)
+        }) { success, error in
+            DispatchQueue.main.async {
+                if success {
+                    // 삭제 후 다시 페칭
+                    self.fetchScreenshots()
+                    
+                    // 선택된 ID 중 삭제된 에셋의 ID만 빼기
+                    let deletedIDs = toDelete.map { $0.localIdentifier }
+                    self.selectedIDs.subtract(deletedIDs)
+                }
+                completion?(success, error)
+            }
+        }
+    }
+}

--- a/CaptureCat/CaptureCat/Util/Extension/Array+.swift
+++ b/CaptureCat/CaptureCat/Util/Extension/Array+.swift
@@ -1,0 +1,16 @@
+//
+//  Array+.swift
+//  CaptureCat
+//
+//  Created by minsong kim on 6/28/25.
+//
+
+import Foundation
+
+extension Array {
+    func chunked(into size: Int) -> [[Element]] {
+        stride(from: 0, to: count, by: size).map { start in
+            Array(self[start..<Swift.min(start + size, count)])
+        }
+    }
+}


### PR DESCRIPTION
## 📚 작업 내용
### toastViewModifier 구현
-`onAppear`는 뷰가 처음 생성될 때만 호출 → 이후 `isShowing` 재설정 시 호출되지 않음
- `onChange(of:old:new:)`를 `content` 레벨에 배치하여 **`isShowing` 상태 변화마다** 타이머를 걸도록 변경
### ScreenshotManager 역할 분리
- **ScreenshotManager**
    - Photo 라이브러리 접근, 원본 `PHAsset` 배열(`assets`) 제공
- **ScreenshotViewModel**
    - `manager.$assets` 구독 → 날짜별로 그룹핑 → `sections: [ScreenshotSection]` 생성
    - 뷰 표시용 가공 로직(필터링, 정렬 등) 담당